### PR TITLE
BaSP-TG-68: table elements alignment corrected

### DIFF
--- a/src/Components/Shared/List/list.module.css
+++ b/src/Components/Shared/List/list.module.css
@@ -39,7 +39,7 @@
   width: 25%;
   max-width: 180px;
   text-align: center;
-  word-break: break-all;
+  word-break: break-word;
   padding: 10px;
 }
 

--- a/src/Components/Shared/List/list.module.css
+++ b/src/Components/Shared/List/list.module.css
@@ -37,7 +37,9 @@
 
 .td{
   width: 25%;
+  max-width: 180px;
   text-align: center;
+  word-break: break-all;
   padding: 10px;
 }
 


### PR DESCRIPTION
Work done on this branch:

Table elements of each resource were misaligned when a very long text was written in a cell, so a small modification was made in the table styles to avoid this problem